### PR TITLE
can create manifest with envs inferred from space

### DIFF
--- a/predix/admin/asset.py
+++ b/predix/admin/asset.py
@@ -2,6 +2,8 @@
 import os
 
 import predix.app
+import predix.config
+import predix.data.asset
 import predix.security.uaa
 import predix.admin.service
 
@@ -14,6 +16,8 @@ class Asset(object):
         super(Asset, self).__init__(*args, **kwargs)
         self.service_name = 'predix-asset'
         self.plan_name = plan_name or 'Free'
+        self.use_class = predix.data.asset.Asset
+
         self.service = predix.admin.service.PredixService(self.service_name,
                 self.plan_name, name=name, uaa=uaa)
 
@@ -29,8 +33,13 @@ class Asset(object):
         starting settings.
         """
         self.service.create()
-        os.environ[self.__module__ + '.uri'] = self.service.settings.data['uri']
-        os.environ[self.__module__ + '.zone_id'] = self.get_zone_id()
+
+        # Set env vars for immediate use
+        uri = predix.config.get_env_key(self.use_class, 'uri')
+        os.environ[uri] = self.service.settings.data['uri']
+
+        zone_id = predix.config.get_env_key(self.use_class, 'zone_id')
+        os.environ[zone_id] = self.get_zone_id()
 
     def grant_client(self, client_id):
         """
@@ -65,8 +74,9 @@ class Asset(object):
         manifest.add_service(self.service.name)
 
         # Add environment variables
-        manifest.add_env_var(self.__module__ + '.uri',
-                self.service.settings.data['uri'])
-        manifest.add_env_var(self.__module__ + '.zone_id', self.get_zone_id())
+        uri = predix.config.get_env_key(self.use_class, 'uri')
+        manifest.add_env_var(uri, self.service.settings.data['uri'])
+        zone_id = predix.config.get_env_key(self.use_class, 'zone_id')
+        manifest.add_env_var(zone_id, self.get_zone_id())
 
         manifest.write_manifest()

--- a/predix/admin/blobstore.py
+++ b/predix/admin/blobstore.py
@@ -1,6 +1,7 @@
 
 import os
 
+import predix.app
 import predix.config
 import predix.admin.service
 import predix.data.blobstore

--- a/predix/admin/service.py
+++ b/predix/admin/service.py
@@ -23,6 +23,10 @@ class CloudFoundryService(object):
         self.config_path = self._get_config_path()
         self.settings = predix.admin.config.ServiceConfig(self.config_path)
 
+        # Handle case of missing service keys and config
+        if self.exists() and not self.settings.data:
+            self.settings.save(self._get_service_config())
+
     def _generate_name(self, space, service_name, plan_name):
         """
         Can generate a name based on the space, service name and plan.
@@ -107,8 +111,8 @@ class PredixService(CloudFoundryService):
     Predix Services extend Cloud Foundry Services by providing
     UAA protections in some standard ways.
     """
-    def __init__(self, service_name, plan_name, uaa=None, *args, **kwargs):
-        super(PredixService, self).__init__(service_name, plan_name, *args, **kwargs)
+    def __init__(self, service_name, plan_name, name=None, uaa=None, *args, **kwargs):
+        super(PredixService, self).__init__(service_name, plan_name, name=name, *args, **kwargs)
 
         # We will create a UAA instance if not given one and authenticate
         self.uaa = self._get_or_create_uaa(uaa)

--- a/predix/data/asset.py
+++ b/predix/data/asset.py
@@ -5,6 +5,7 @@ import uuid
 import logging
 import requests
 
+import predix.config
 import predix.service
 import predix.security.uaa
 
@@ -16,14 +17,15 @@ class Asset(object):
     def __init__(self, *args, **kwargs):
         super(Asset, self).__init__(*args, **kwargs)
 
-        ns = 'predix.admin.asset'
-        self.zone_id = os.environ.get(ns + '.zone_id')
+        key = predix.config.get_env_key(self, 'zone_id')
+        self.zone_id = os.environ.get(key)
         if not self.zone_id:
-            raise ValueError("%s.zone_id environment unset" % ns)
+            raise ValueError("%s environment unset" % key)
 
-        self.uri = os.environ.get(ns + '.uri')
+        key = predix.config.get_env_key(self, 'uri')
+        self.uri = os.environ.get(key)
         if not self.uri:
-            raise ValueError("%s.uri environment unset" % ns)
+            raise ValueError("%s environment unset" % key)
 
         self.service = predix.service.Service(self.zone_id)
 

--- a/predix/data/timeseries.py
+++ b/predix/data/timeseries.py
@@ -7,6 +7,7 @@ import logging
 import datetime
 import websocket
 
+import predix.config
 import predix.service
 
 
@@ -23,26 +24,34 @@ class TimeSeries(object):
     def __init__(self, read=True, write=True, *args, **kwargs):
         super(TimeSeries, self).__init__(*args, **kwargs)
 
-        ns = 'predix.admin.timeseries'
-        self.query_zone_id = os.environ.get(ns + '.query.zone_id')
-        self.query_uri = os.environ.get(ns + '.query.uri')
+        self.zone_id = None
         if read:
+            key = predix.config.get_env_key(self, 'query_zone_id')
+            self.query_zone_id = os.environ.get(key)
             if not self.query_zone_id:
-                raise ValueError("%s.query.zone_id env unset" % ns)
+                raise ValueError("%s env unset" % key)
 
+            key = predix.config.get_env_key(self, 'query_uri')
+            self.query_uri = os.environ.get(key)
             if not self.query_uri:
-                raise ValueError("%s.query.uri environment unset" % ns)
+                raise ValueError("%s environment unset" % key)
 
-        self.ingest_zone_id = os.environ.get(ns + '.ingest.zone_id')
-        self.ingest_uri = os.environ.get(ns + '.ingest.uri')
+            self.zone_id = self.query_zone_id
+
         if write:
+            key = predix.config.get_env_key(self, 'ingest_zone_id')
+            self.ingest_zone_id = os.environ.get(key)
             if not self.ingest_zone_id:
-                raise ValueError("%s.ingest.zone_id env unset" % ns)
+                raise ValueError("%s env unset" % key)
 
+            key = predix.config.get_env_key(self, 'ingest_uri')
+            self.ingest_uri = os.environ.get(key)
             if not self.ingest_uri:
-                raise ValueError("%s.ingest.uri environment unset" % ns)
+                raise ValueError("%s environment unset" % key)
 
-        self.service = predix.service.Service(self.query_zone_id)
+            self.zone_id = self.ingest_zone_id
+
+        self.service = predix.service.Service(self.zone_id)
 
         # Store a websocket connection once opened
         self.ws = None

--- a/predix/data/weather.py
+++ b/predix/data/weather.py
@@ -2,6 +2,7 @@
 import os
 import urllib
 
+import predix.config
 import predix.service
 
 
@@ -9,14 +10,15 @@ class WeatherForecast(object):
     def __init__(self, *args, **kwargs):
         super(WeatherForecast, self).__init__(*args, **kwargs)
 
-        ns = 'predix.admin.weather'
-        self.uri = os.environ.get(ns + '.uri')
+        key = predix.config.get_env_key(self, 'uri')
+        self.uri = os.environ.get(key)
         if not self.uri:
-            raise ValueError("%s.uri environment unset" % ns)
+            raise ValueError("%s environment unset" % key)
 
-        self.zone_id = os.environ.get(ns + '.zone_id')
+        key = predix.config.get_env_key(self, 'zone_id')
+        self.zone_id = os.environ.get(key)
         if not self.zone_id:
-            raise ValueError("%s.zone_id environment unset" % ns)
+            raise ValueError("%s environment unset" % key)
 
         self.service = predix.service.Service(self.zone_id)
 

--- a/predix/security/acs.py
+++ b/predix/security/acs.py
@@ -4,6 +4,7 @@ import uuid
 import urllib
 import logging
 
+import predix.config
 import predix.service
 
 
@@ -18,14 +19,15 @@ class AccessControl(object):
     """
     def __init__(self):
 
-        ns = 'predix.admin.acs'
-        self.zone_id = os.environ.get(ns + '.zone_id')
+        key = predix.config.get_env_key(self, 'zone_id')
+        self.zone_id = os.environ.get(key)
         if not self.zone_id:
-            raise ValueError("%s.zone_id environment unset" % ns)
+            raise ValueError("%s environment unset" % key)
 
-        self.uri = os.environ.get(ns + '.uri')
+        key = predix.config.get_env_key(self, 'uri')
+        self.uri = os.environ.get(key)
         if not self.uri:
-            raise ValueError("%s.uri environment unset" % ns)
+            raise ValueError("%s environment unset" % key)
 
         self.service = predix.service.Service(self.zone_id)
 

--- a/predix/security/uaa.py
+++ b/predix/security/uaa.py
@@ -9,6 +9,7 @@ import datetime
 import dateutil.parser
 
 import predix.app
+import predix.config
 
 class UserAccountAuthentication(object):
     """
@@ -20,10 +21,10 @@ class UserAccountAuthentication(object):
     """
     def __init__(self):
 
-        self.key = 'predix.admin.uaa.uri'
-        self.uri = os.environ.get(self.key)
+        key = predix.config.get_env_key(self, 'uri')
+        self.uri = os.environ.get(key)
         if not self.uri:
-            raise ValueError("%s environment unset" % self.key)
+            raise ValueError("%s environment unset" % key)
 
         self.authenticated = False
         self.client = None
@@ -320,6 +321,10 @@ class UserAccountAuthentication(object):
         the application.
         """
         manifest = predix.app.Manifest(manifest_path)
-        manifest.add_env_var(self.__module__ + '.client_id', client_id)
-        manifest.add_env_var(self.__module__ + '.client_secret', client_secret)
+
+        client_id_key = predix.config.get_env_key(self, 'client_id')
+        manifest.add_env_var(client_id_key, client_id)
+        client_secret_key = predix.config.get_env_key(self, 'client_secret')
+        manifest.add_env_var(client_secret_key, client_secret)
+
         manifest.write_manifest()


### PR DESCRIPTION
For spaces that created services by means other than predixpy, the `create_manifest_from_space()` method will identify the service instances, create service keys, and populate the manifest with needed environment variables.

Here's an example usage:
```
import predix.app
app = predix.app.Manifest('manifest.yml')
app.create_manifest_from_space()
timeseries = app.get_timeseries()
```
