### PR TITLE
Separate admin app functionality and help with service marketplace insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,25 @@ If you want to install from source, see developer section below.
 
 # Basic Usage
 
-## Administration
+There are two modes of operations that PredixPy helps to solve.
+
+1. You are administering a cloud foundry space and want to automate the
+   creation and configuration of services.
+2. You are using service instances from cloud foundry and running your app
+   locally or on cloud foundry.
+
+There are two separate application frameworks for managing this process that
+revolve around writing or reading configuration details to the manifest.yml
+
+## Administration Mode
 
 When you have done a `cf login` to a Cloud Foundry endpoint you can begin
 creating services in Python.
 
 ```
 # The manifest can be used for managing your work
-import predix.app
-app = predix.app.Manifest('manifest.yml')
+import predix.admin.app
+app = predix.admin.app.Manifest()
 
 # Create a UAA service instance as most services require it, and a client
 # that your application can use for accessingn services.
@@ -40,7 +50,7 @@ app.create_client('client-id', 'client-secret')
 app.create_timeseries()
 ```
 
-## Applications
+## Application Mode
 
 Once your space has been configured like the above example, you can use
 PredixPy to work with the services in your applications.
@@ -51,7 +61,7 @@ PredixPy to work with the services in your applications.
 # into your process.
 
 import predix.app
-app = predix.app.Manifest('manifest.yml')
+app = predix.app.Manifest()
 ts = app.get_timeseries()
 ts.send('TEMP', 70.1)
 print(ts.get_values('TEMP'))

--- a/predix/admin/acs.py
+++ b/predix/admin/acs.py
@@ -1,7 +1,6 @@
 
 import os
 
-import predix.app
 import predix.config
 import predix.security.uaa
 import predix.security.acs
@@ -61,13 +60,15 @@ class AccessControl(object):
 
         return self.service.uaa.uaac.get_client(client_id)
 
-    def add_to_manifest(self, manifest_path):
+    def add_to_manifest(self, manifest):
         """
-        Add details to the manifest that applications using
-        this service may need to consume.
-        """
-        manifest = predix.app.Manifest(manifest_path)
+        Add useful details to the manifest about this service
+        so that it can be used in an application.
 
+        :param manifest: An predix.admin.app.Manifest object
+            instance that manages reading/writing manifest config
+            for a cloud foundry app.
+        """
         # Add this service to list of services
         manifest.add_service(self.service.name)
 

--- a/predix/admin/analytics.py
+++ b/predix/admin/analytics.py
@@ -1,5 +1,4 @@
 
-import predix.app
 import predix.security.uaa
 import predix.admin.service
 

--- a/predix/admin/app.py
+++ b/predix/admin/app.py
@@ -1,0 +1,156 @@
+
+import predix.app
+import predix.admin.uaa
+import predix.admin.acs
+import predix.admin.asset
+import predix.admin.weather
+import predix.admin.cf.spaces
+import predix.admin.blobstore
+import predix.admin.timeseries
+
+
+class Manifest(predix.app.Manifest):
+    """
+    Extends Application Manifest with administrative
+    functions for creating and configuring services.
+    """
+    def __init__(self, *args, **kwargs):
+        super(Manifest, self).__init__(*args, **kwargs)
+
+        self.space = predix.admin.cf.spaces.Space()
+
+        self.supported = {
+            'predix-uaa': predix.admin.uaa.UserAccountAuthentication,
+            'predix-acs': predix.admin.acs.AccessControl,
+            'predix-asset': predix.admin.asset.Asset,
+            'predix-blobstore': predix.admin.blobstore.BlobStore,
+            'predix-timeseries': predix.admin.timeseries.TimeSeries,
+            'predix-weather': predix.admin.weather.WeatherForecast,
+        }
+
+    def create_manifest_from_space(self):
+        """
+        Populate a manifest file generated from details from the
+        cloud foundry space environment.
+        """
+        space = predix.admin.cf.spaces.Space()
+
+        summary = space.get_space_summary()
+        for instance in summary['services']:
+            service_type = instance['service_plan']['service']['label']
+            name = instance['name']
+            if service_type == 'predix-uaa':
+                uaa = predix.admin.uaa.UserAccountAuthentication(name=name)
+                uaa.add_to_manifest(self)
+            elif service_type == 'predix-acs':
+                acs = predix.admin.acs.AccessControl(name=name)
+                acs.add_to_manifest(self)
+            elif service_type == 'predix-asset':
+                asset = predix.admin.asset.Asset(name=name)
+                asset.add_to_manifest(self)
+            elif service_type == 'predix-timeseries':
+                timeseries = predix.admin.timeseries.TimeSeries(name=name)
+                timeseries.add_to_manifest(self)
+            elif service_type == 'predix-blobstore':
+                blobstore = predix.admin.blobstore.BlobStore(name=name)
+                blobstore.add_to_manifest(self)
+            elif service_type == 'us-weather-forecast':
+                weather = predix.admin.weather.WeatherForecast(name=name)
+                weather.add_to_manifest(self)
+            else:
+                logging.warn("Unsupported service type: %s" % service_type)
+
+    def create_uaa(self, admin_secret):
+        """
+        Creates an instance of UAA Service.
+
+        :param admin_secret: The secret password for administering the service
+            such as adding clients and users.
+        """
+        uaa = predix.admin.uaa.UserAccountAuthentication()
+        if not uaa.exists():
+            uaa.create(admin_secret)
+            uaa.add_to_manifest(self)
+        return uaa
+
+    def create_client(self, client_id, client_secret):
+        """
+        Create a client and add it to the manifest.
+
+        :param client_id: The client id used to authenticate as a client
+            in UAA.
+
+        :param client_secret: The secret password used by a client to
+            authenticate and generate a UAA token.
+        """
+        uaa = predix.admin.uaa.UserAccountAuthentication()
+        uaa.create_client(client_id, client_secret)
+        uaa.add_client_to_manifest(client_id, client_secret, self)
+
+    def create_timeseries(self):
+        """
+        Creates an instance of the Time Series Service.
+        """
+        ts = predix.admin.timeseries.TimeSeries()
+        ts.create()
+
+        client_id = self.get_client_id()
+        if client_id:
+            ts.grant_client(client_id)
+
+        ts.add_to_manifest(self)
+        return ts
+
+    def create_asset(self):
+        """
+        Creates an instance of the Asset Service.
+        """
+        asset = predix.admin.asset.Asset()
+        asset.create()
+
+        client_id = self.get_client_id()
+        if client_id:
+            asset.grant_client(client_id)
+
+        asset.add_to_manifest(self)
+        return asset
+
+    def create_acs(self):
+        """
+        Creates an instance of the Asset Service.
+        """
+        acs = predix.admin.acs.AccessControl()
+        acs.create()
+
+        client_id = self.get_client_id()
+        if client_id:
+            acs.grant_client(client_id)
+
+        acs.grant_client(client_id)
+        acs.add_to_manifest(self)
+        return acs
+
+    def create_weather(self):
+        """
+        Creates an instance of the Asset Service.
+        """
+        weather = predix.admin.weather.WeatherForecast()
+        weather.create()
+
+        client_id = self.get_client_id()
+        if client_id:
+            weather.grant_client(client_id)
+
+        weather.grant_client(client_id)
+        weather.add_to_manifest(self)
+        return weather
+
+    def create_blobstore(self):
+        """
+        Creates an instance of the BlobStore Service.
+        """
+        blobstore = predix.admin.blobstore.BlobStore()
+        blobstore.create()
+
+        blobstore.add_to_manifest(self)
+        return blobstore

--- a/predix/admin/app.py
+++ b/predix/admin/app.py
@@ -154,3 +154,33 @@ class Manifest(predix.app.Manifest):
 
         blobstore.add_to_manifest(self)
         return blobstore
+
+    def get_service_marketplace(self, available=True, unavailable=False,
+            deprecated=False):
+        """
+        Returns a list of service names.  Can return all services, just
+        those supported by PredixPy, or just those not yet supported by
+        PredixPy.
+
+        :param available: Return the services that are
+            available in PredixPy.  (Defaults to True)
+
+        :param unavailable: Return the services that are not yet
+            supported by PredixPy.  (Defaults to False)
+
+        :param deprecated: Return the services that are
+            supported by PredixPy but no longer available. (True)
+        """
+
+        supported = set(self.supported.keys())
+        all_services = set(self.space.get_services())
+
+        results = set()
+        if available:
+            results.update(supported)
+        if unavailable:
+            results.update(all_services.difference(supported))
+        if deprecated:
+            results.update(supported.difference(all_services))
+
+        return list(results)

--- a/predix/admin/asset.py
+++ b/predix/admin/asset.py
@@ -1,7 +1,6 @@
 
 import os
 
-import predix.app
 import predix.config
 import predix.data.asset
 import predix.security.uaa
@@ -63,13 +62,15 @@ class Asset(object):
         """
         return self.service.settings.data['zone']['http-header-value']
 
-    def add_to_manifest(self, manifest_path):
+    def add_to_manifest(self, manifest):
         """
-        Add details to the manifest that applications using
-        this service may need to consume.
-        """
-        manifest = predix.app.Manifest(manifest_path)
+        Add useful details to the manifest about this service
+        so that it can be used in an application.
 
+        :param manifest: An predix.admin.app.Manifest object
+            instance that manages reading/writing manifest config
+            for a cloud foundry app.
+        """
         # Add this service to list of services
         manifest.add_service(self.service.name)
 

--- a/predix/admin/blobstore.py
+++ b/predix/admin/blobstore.py
@@ -1,7 +1,6 @@
 
 import os
 
-import predix.app
 import predix.config
 import predix.admin.service
 import predix.data.blobstore
@@ -50,13 +49,15 @@ class BlobStore(object):
         os.environ[secret_access_key] = self.service.settings.data['secret_access_key']
 
 
-    def add_to_manifest(self, manifest_path):
+    def add_to_manifest(self, manifest):
         """
-        Add details to the mamnifest that applications using
-        this service may need to consume.
-        """
-        manifest = predix.app.Manifest(manifest_path)
+        Add useful details to the manifest about this service
+        so that it can be used in an application.
 
+        :param manifest: An predix.admin.app.Manifest object
+            instance that manages reading/writing manifest config
+            for a cloud foundry app.
+        """
         # Add this service to the list of services
         manifest.add_service(self.service.name)
 

--- a/predix/admin/config.py
+++ b/predix/admin/config.py
@@ -18,6 +18,7 @@ class ServiceConfig(object):
         Save the given configuration data.
         """
         self.data = data
+        self._write_service_config()
 
     def _get_service_config(self):
         """

--- a/predix/admin/ie/parking.py
+++ b/predix/admin/ie/parking.py
@@ -1,7 +1,6 @@
 
 import os
 
-import predix.app
 import predix.security.uaa
 import predix.admin.service
 
@@ -58,13 +57,15 @@ class ParkingPlanning(object):
         """
         return self.service.settings.data['zone']['http-header-value']
 
-    def add_to_manifest(self, manifest_path):
+    def add_to_manifest(self, manifest):
         """
-        Add details to the manifest that applications using
-        this service may need to consume.
-        """
-        manifest = predix.app.Manifest(manifest_path)
+        Add useful details to the manifest about this service
+        so that it can be used in an application.
 
+        :param manifest: An predix.admin.app.Manifest object
+            instance that manages reading/writing manifest config
+            for a cloud foundry app.
+        """
         # Add this service to list of services
         manifest.add_service(self.service.name)
 

--- a/predix/admin/timeseries.py
+++ b/predix/admin/timeseries.py
@@ -2,7 +2,6 @@
 import os
 import urlparse
 
-import predix.app
 import predix.config
 import predix.security.uaa
 import predix.admin.service
@@ -99,13 +98,15 @@ class TimeSeries(object):
         query_uri = urlparse.urlparse(query_uri)
         return query_uri.scheme + '://' + query_uri.netloc
 
-    def add_to_manifest(self, manifest_path):
+    def add_to_manifest(self, manifest):
         """
-        Add details to the manifest that applications using
-        this service may need to consume.
-        """
-        manifest = predix.app.Manifest(manifest_path)
+        Add useful details to the manifest about this service
+        so that it can be used in an application.
 
+        :param manifest: An predix.admin.app.Manifest object
+            instance that manages reading/writing manifest config
+            for a cloud foundry app.
+        """
         # Add this service to list of services
         manifest.add_service(self.service.name)
 

--- a/predix/admin/uaa.py
+++ b/predix/admin/uaa.py
@@ -1,7 +1,6 @@
 
 import os
 
-import predix.app
 import predix.config
 import predix.admin.service
 
@@ -52,13 +51,15 @@ class UserAccountAuthentication(object):
         # Once we create it login
         self.authenticate()
 
-    def add_to_manifest(self, manifest_path):
+    def add_to_manifest(self, manifest):
         """
-        Add details to the manifest that applications using
-        this service may need to consume.
-        """
-        manifest = predix.app.Manifest(manifest_path)
+        Add useful details to the manifest about this service
+        so that it can be used in an application.
 
+        :param manifest: An predix.admin.app.Manifest object
+            instance that manages reading/writing manifest config
+            for a cloud foundry app.
+        """
         # Add this service to list of services
         manifest.add_service(self.service.name)
 
@@ -87,13 +88,13 @@ class UserAccountAuthentication(object):
         assert self.is_admin, "Must authenticate() as admin to create client"
         return self.uaac.create_client(client_id, client_secret)
 
-    def add_client_to_manifest(self, client_id, client_secret, manifest_path):
+    def add_client_to_manifest(self, client_id, client_secret, manifest):
         """
         Add the client credentials to the specified manifest.
         """
         assert self.is_admin, "Must authenticate() as admin to create client"
         return self.uaac.add_client_to_manifest(client_id, client_secret,
-                manifest_path)
+                manifest)
 
     def _get_admin_secret(self):
         return self.service.settings.data['adminClientSecret']

--- a/predix/admin/weather.py
+++ b/predix/admin/weather.py
@@ -1,7 +1,6 @@
 
 import os
 
-import predix.app
 import predix.config
 import predix.admin.service
 import predix.data.weather
@@ -38,9 +37,15 @@ class WeatherForecast(object):
         uri = predix.config.get_env_key(self.use_class, 'uri')
         os.environ[uri] = self.service.settings.data['uri']
 
-    def add_to_manifest(self, manifest_path):
-        manifest = predix.app.Manifest(manifest_path)
+    def add_to_manifest(self, manifest):
+        """
+        Add useful details to the manifest about this service
+        so that it can be used in an application.
 
+        :param manifest: An predix.admin.app.Manifest object
+            instance that manages reading/writing manifest config
+            for a cloud foundry app.
+        """
         # Add this service to list of services
         manifest.add_service(self.service.name)
 

--- a/predix/security/uaa.py
+++ b/predix/security/uaa.py
@@ -315,16 +315,15 @@ class UserAccountAuthentication(object):
         else:
             response.raise_for_status()
 
-    def add_client_to_manifest(self, client_id, client_secret, manifest_path):
+    def add_client_to_manifest(self, client_id, client_secret, manifest):
         """
         Add the given client / secret to the manifest for use in
         the application.
         """
-        manifest = predix.app.Manifest(manifest_path)
-
-        client_id_key = predix.config.get_env_key(self, 'client_id')
+        client_id_key = 'PREDIX_APP_CLIENT_ID'
         manifest.add_env_var(client_id_key, client_id)
-        client_secret_key = predix.config.get_env_key(self, 'client_secret')
+
+        client_secret_key = 'PREDIX_APP_CLIENT_SECRET'
         manifest.add_env_var(client_secret_key, client_secret)
 
         manifest.write_manifest()


### PR DESCRIPTION
A few notable changes:

- Will default to 'manifest.yml' in current directory from `predix.app.Manifest()` unless otherwise specified
- Separated `predix.app.Manifest` and `predix.admin.app.Manifest` where you can use the latter to call methods like `create_uaa()` and the former can only `get_uaa()` if it exists already
- Added method to `predix.admin.app` to `get_service_marketplace()` which allows for quickly identifying all services available in a space, only those supported by predixpy, those not yet supported, etc.
- Updated `README.md` with the new usage descriptions of these modes